### PR TITLE
Refactor message handling and data updates

### DIFF
--- a/src/data_controller.py
+++ b/src/data_controller.py
@@ -91,6 +91,10 @@ class DataController:
             if self.plot:
                 self.plot.update_plot((index_num, value_num))
 
+            # Update current value display
+            if self.display:
+                self.display.display(value_num)
+
             # Update history list widget
             if self.history:
                 # Insert new item at the top


### PR DESCRIPTION
## Summary
- add `MessageHelper` for consistent dialogs
- remove duplicated QMessageBox usage from `MainWindow`
- update `DataController` to refresh the current value display
- adjust `SaveManager.create_metadata` to keep custom group names
- translate some comments to English
- move save logic into `SaveManager` with auto/manual helpers
- simplify `MainWindow` accordingly
- test new save helper methods

## Testing
- `pytest -q`
- `python tests/run_tests.py` *(fails: ImportError: PySide6 not available)*

------
https://chatgpt.com/codex/tasks/task_e_685abfe44fe4832eb6a8479262c9c2c2