### PR TITLE
Switch to pyqtgraph with histogram support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "PySide6>=6.5.0",
     "numpy>=1.24.0",
     "matplotlib>=3.7.0",
+    "pyqtgraph>=0.13.0",
     "scipy>=1.10.0",
     "pyserial>=3.5",
     "pillow>=9.5.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 PySide6
 matplotlib
 pyserial
+pyqtgraph

--- a/src/data_controller.py
+++ b/src/data_controller.py
@@ -4,9 +4,15 @@
 """Data controller for managing measurements and plot updates."""
 
 from typing import Optional, List, Tuple, Dict, Union
+from datetime import datetime
 
 try:  # pragma: no cover - optional dependency for headless testing
-    from PySide6.QtWidgets import QLCDNumber, QListWidget  # type: ignore
+    from PySide6.QtWidgets import (
+        QLCDNumber,
+        QListWidget,
+        QTableView,
+    )  # type: ignore
+    from PySide6.QtGui import QStandardItemModel, QStandardItem  # type: ignore
     from PySide6.QtCore import Qt  # type: ignore
 except Exception:  # ImportError or missing Qt libraries
 
@@ -34,6 +40,26 @@ except Exception:  # ImportError or missing Qt libraries
         def clear(self):
             pass
 
+    class QTableView:  # pragma: no cover - fallback stub
+        def setModel(self, *args, **kwargs):
+            pass
+
+    class QStandardItemModel:  # pragma: no cover - fallback stub
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def setHorizontalHeaderLabels(self, *args, **kwargs):
+            pass
+
+        def appendRow(self, *args, **kwargs):
+            pass
+
+        def rowCount(self):
+            return 0
+
+        def removeRow(self, *args, **kwargs):
+            pass
+
     class _Alignment:
         AlignRight = 0
 
@@ -57,6 +83,7 @@ class DataController:
         plot_widget: PlotWidget,
         display_widget: Optional[QLCDNumber] = None,
         history_widget: Optional[QListWidget] = None,
+        table_widget: Optional[QTableView] = None,
         max_history: int = MAX_HISTORY_SIZE,
     ):
         """Initialise the data controller.
@@ -70,8 +97,15 @@ class DataController:
         self.plot = plot_widget
         self.display = display_widget
         self.history = history_widget
-        self.data_points: List[Tuple[int, float]] = []
+        self.table = table_widget
+        self.table_model: Optional[QStandardItemModel] = None
+        self.data_points: List[Tuple[int, float, str]] = []
         self.max_history = max_history
+
+        if self.table is not None:
+            self.table_model = QStandardItemModel(0, 3, self.table)
+            self.table_model.setHorizontalHeaderLabels(["Index", "Value (µs)", "Time"])
+            self.table.setModel(self.table_model)
 
     def add_data_point(self, index: Union[int, str], value: Union[float, str]) -> None:
         """Add a new point and update the optional UI widgets."""
@@ -81,9 +115,10 @@ class DataController:
             # Sicherstellen, dass die Werte numerisch sind
             index_num = int(index)
             value_num = float(value)
+            timestamp = datetime.now().strftime("%H:%M:%S")
 
             # Add data and drop oldest when maximum size is reached
-            self.data_points.append((index_num, value_num))
+            self.data_points.append((index_num, value_num, timestamp))
             if len(self.data_points) > self.max_history:
                 self.data_points.pop(0)
 
@@ -99,12 +134,20 @@ class DataController:
             if self.history:
                 # Insert new item at the top
                 self.history.insertItem(0, f"{value_num} µs : {index_num}")
-                # Right align text for readability
                 self.history.item(0).setTextAlignment(Qt.AlignmentFlag.AlignRight)
 
-                # Keep list size within limit
                 while self.history.count() > self.max_history:
                     self.history.takeItem(self.history.count() - 1)
+
+            if self.table_model is not None:
+                row = [
+                    QStandardItem(str(index_num)),
+                    QStandardItem(str(value_num)),
+                    QStandardItem(timestamp),
+                ]
+                self.table_model.appendRow(row)
+                while self.table_model.rowCount() > self.max_history:
+                    self.table_model.removeRow(0)
 
         except (ValueError, TypeError) as e:
             Debug.error(f"Failed to convert values: {e}", exc_info=True)
@@ -128,6 +171,10 @@ class DataController:
             # Clear the history list
             if self.history:
                 self.history.clear()
+
+            if self.table_model is not None:
+                while self.table_model.rowCount() > 0:
+                    self.table_model.removeRow(0)
 
         except (AttributeError, RuntimeError) as e:
             Debug.error(f"Failed to reset UI elements: {e}", exc_info=True)
@@ -168,13 +215,13 @@ class DataController:
 
         return stats
 
-    def get_data_as_list(self) -> List[Tuple[int, float]]:
+    def get_data_as_list(self) -> List[Tuple[int, float, str]]:
         """Return all stored data points as a list."""
         return self.data_points.copy()
 
     def get_csv_data(self) -> List[List[str]]:
         """Prepare the stored data for CSV export."""
-        result: List[List[str]] = [["Index", "Value (µs)"]]
-        for idx, value in self.data_points:
-            result.append([str(idx), str(value)])
+        result: List[List[str]] = [["Index", "Value (µs)", "Time"]]
+        for idx, value, timestamp in self.data_points:
+            result.append([str(idx), str(value), timestamp])
         return result

--- a/src/main_window.py
+++ b/src/main_window.py
@@ -7,7 +7,7 @@ from PySide6.QtWidgets import (  # pylint: disable=no-name-in-module
 from PySide6.QtCore import QTimer, Qt  # pylint: disable=no-name-in-module
 from src.device_manager import DeviceManager
 from src.control import ControlWidget
-from src.plot import PlotWidget
+from src.plot import PlotWidget, HistogramWidget
 from src.debug_utils import Debug
 from src.helper_classes import (
     import_config,
@@ -124,6 +124,10 @@ class MainWindow(QMainWindow):
         )
         QVBoxLayout(self.ui.timePlot).addWidget(self.plot)
 
+        # Histogram plot
+        self.histogram = HistogramWidget()
+        QVBoxLayout(self.ui.histogramm).addWidget(self.histogram)
+
     def _setup_data_controller(self):
         """
         Richtet den Daten-Controller ein.
@@ -131,6 +135,7 @@ class MainWindow(QMainWindow):
         self.data_controller = DataController(
             plot_widget=self.plot,
             display_widget=self.ui.currentCount,
+            table_widget=self.ui.tableView,
             max_history=CONFIG["data_controller"]["max_history_size"],
         )
 
@@ -384,6 +389,9 @@ class MainWindow(QMainWindow):
             value (float): Der gemessene Wert
         """
         self.data_controller.add_data_point(index, value)
+        # Histogram aktualisieren
+        values = [p[1] for p in self.data_controller.data_points]
+        self.histogram.update_histogram(values)
         # Daten als ungespeichert markieren
         self.data_saved = False
         self.save_manager.mark_unsaved()

--- a/src/plot.py
+++ b/src/plot.py
@@ -1,270 +1,206 @@
-from typing import Tuple, Optional
-import numpy as np
-import matplotlib
-try:  # pragma: no cover - optional Qt backend for headless tests
-    from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg
-    matplotlib.use("Qt5Agg")
-except Exception:  # If no Qt backend is available fall back to Agg
-    from matplotlib.backends.backend_agg import FigureCanvasAgg as FigureCanvasQTAgg
-    matplotlib.use("Agg")
+"""Plot widgets using :mod:`pyqtgraph`."""
 
-from matplotlib.figure import Figure
+from __future__ import annotations
+
+from typing import Iterable, Optional, Tuple
+import numpy as np
+
+try:  # pragma: no cover - optional dependency during headless tests
+    import pyqtgraph as pg
+except Exception:  # pragma: no cover - fallback stubs
+    from PySide6.QtWidgets import QWidget
+
+    class _DummyPlotWidget(QWidget):
+        def __init__(self, *_, **__):
+            super().__init__()
+
+        def plot(self, *_, **__):
+            return self
+
+        def setData(self, *_, **__):
+            pass
+
+        def clear(self):
+            pass
+
+        def addItem(self, *_):
+            pass
+
+        def autoRange(self, *_, **__):
+            pass
+
+        def setBackground(self, *_):
+            pass
+
+        def showGrid(self, *_, **__):
+            pass
+
+        def setLabel(self, *_, **__):
+            pass
+
+        def setTitle(self, *_, **__):
+            pass
+
+    pg = type("pg", (), {"PlotWidget": _DummyPlotWidget, "mkPen": lambda *a, **k: None, "BarGraphItem": object})()  # type: ignore
+
 from src.debug_utils import Debug
 
 
-class PlotWidget(FigureCanvasQTAgg):
-    """
-    A matplotlib-based plot widget for displaying data in real-time.
-    Optimized for efficient updates and memory usage.
-    """
+class PlotWidget(pg.PlotWidget):
+    """Real-time line plot widget."""
 
     def __init__(
         self,
         max_plot_points: int = 100,
-        width: int = 5,
-        height: int = 4,
-        dpi: int = 100,
+        width: int | None = None,
+        height: int | None = None,
+        dpi: int | None = None,
         fontsize: int = 10,
         xlabel: str = "X",
         ylabel: str = "Y",
         title: str = "Data",
-    ):
-        """
-        Initialize the plot widget with the given parameters.
+    ) -> None:
+        super().__init__()
 
-        Args:
-            max_plot_points (int): Maximum number of points to display in the plot
-            width (int): Width of the plot in inches
-            height (int): Height of the plot in inches
-            dpi (int): DPI (dots per inch) of the plot
-            fontsize (int): Font size to use in the plot
-            xlabel (str): Label for the x-axis
-            ylabel (str): Label for the y-axis
-            title (str): Title of the plot
-        """
-        # Debugging für Plot-Initialisierung
-        try:
-            Debug.info(
-                f"Initializing PlotWidget with max_points={max_plot_points}, title={title}"
-            )
+        Debug.info(
+            f"Initializing PlotWidget with max_points={max_plot_points}, title={title}"
+        )
 
-            # Set up the figure and axes for the plot
-            self.fig = Figure(figsize=(width / dpi, height / dpi), dpi=dpi)
-            self.axes = self.fig.add_subplot(111)
+        self.setBackground(None)
+        self.showGrid(x=True, y=True, alpha=0.3)
 
-            # Initialize the canvas with transparent background
-            super().__init__(self.fig)
-            # Setze den Hintergrund des Canvas auf transparent
-            self.setStyleSheet("background-color: transparent;")
+        self.max_plot_points = max_plot_points
+        self.fontsize = fontsize
 
-            # Configure plot settings
-            self.max_plot_points = max_plot_points
-            self.fontsize = fontsize
-            self.axes.tick_params(labelsize=self.fontsize)
+        self._x_data = np.zeros(max_plot_points)
+        self._y_data = np.zeros(max_plot_points)
+        self._data_count = 0
 
-            # Initialize data arrays with pre-allocated buffers for efficiency
-            self._x_data = np.zeros(max_plot_points)
-            self._y_data = np.zeros(max_plot_points)
-            self._data_count = 0
+        pen = pg.mkPen("w", width=1.5)
+        self.line = self.plot([], [], pen=pen, symbol="o", symbolSize=3)
 
-            # Set up the plot line with increased visibility
-            (self.line,) = self.axes.plot(
-                [], [], "w-", linewidth=1.5, marker="o", markersize=3
-            )
+        self.setLabel("bottom", xlabel)
+        self.setLabel("left", ylabel)
+        self.setTitle(title)
 
-            # Configure axes labels and appearance
-            self.axes.set_xlabel(xlabel, fontsize=fontsize)
-            self.axes.set_ylabel(ylabel, fontsize=fontsize)
-            self.axes.set_title(title, fontsize=fontsize + 2)
-            self.axes.grid(True, alpha=0.3)
+        self._plot_config = {"xlabel": xlabel, "ylabel": ylabel, "title": title}
 
-            # Make background transparent to match application theme
-            self.fig.patch.set_facecolor("none")  # Explizit transparent setzen
-            self.axes.patch.set_facecolor("none")  # Explizit transparent setzen
-            self.fig.patch.set_alpha(0.0)
-            self.axes.patch.set_alpha(0.0)
-
-            # Setze explizit clear=True für FigureCanvasQTAgg, um Transparenz zu ermöglichen
-            self.fig.set_facecolor("none")
-            self.fig.tight_layout(pad=1.0)
-
-            # Achsen und Text in Weiß für bessere Sichtbarkeit
-            for spine in ["top", "bottom", "left", "right"]:
-                self.axes.spines[spine].set_color("white")
-            self.axes.tick_params(colors="white")
-            self.axes.yaxis.label.set_color("white")
-            self.axes.xaxis.label.set_color("white")
-            self.axes.title.set_color("white")
-
-            # Initial plot appearance
-            # self.fig.tight_layout()
-            self.axes.autoscale(enable=True, axis="both", tight=True)
-
-            # Store plot configuration
-            self._plot_config = {"xlabel": xlabel, "ylabel": ylabel, "title": title}
-
-            Debug.info("PlotWidget initialization complete")
-        except Exception as e:
-            Debug.error(f"Error initializing PlotWidget: {e}")
-
+    # ------------------------------------------------------------------
     def update_plot(self, new_point: Tuple[float, float]) -> None:
-        """
-        Add a new data point to the plot and update the display.
-        Optimized for efficient updates with large datasets.
+        """Add a new point to the line plot."""
 
-        Args:
-            new_point (Tuple[float, float]): The new point to add (x, y)
-        """
         x, y = new_point
 
-        # Add the new point to our data arrays
         if self._data_count < self.max_plot_points:
-            # Still filling the initial buffer
             self._x_data[self._data_count] = x
             self._y_data[self._data_count] = y
             self._data_count += 1
         else:
-            # Buffer full, shift data and add new point at the end
             self._x_data = np.roll(self._x_data, -1)
             self._y_data = np.roll(self._y_data, -1)
             self._x_data[-1] = x
             self._y_data[-1] = y
 
-        # Update the line data for display
-        self.line.set_data(
+        self.line.setData(
             self._x_data[: self._data_count], self._y_data[: self._data_count]
         )
+        self.autoRange()
 
-        # Adjust plot limits only when needed for efficiency
-        self._adjust_limits()
+    # ------------------------------------------------------------------
+    def clear(self) -> None:  # type: ignore[override]
+        """Clear the plot data."""
 
-        # Redraw the canvas
-        self.fig.canvas.draw()  # Statt draw_idle() für sofortige Aktualisierung
-        self.fig.canvas.flush_events()
-        self.update()  # Löst ein explizites QWidget repaint aus
-
-    def _adjust_limits(self) -> None:
-        """
-        Adjust the plot limits to show all data points with some margin.
-        Uses smart rescaling to avoid constant limit changes.
-        """
-        if self._data_count <= 1:
-            # Not enough data for meaningful limits
-            self.axes.set_xlim(0, 10)
-            self.axes.set_ylim(0, 10)
-            return
-
-        # Get current data ranges
-        x_min, x_max = np.min(self._x_data[: self._data_count]), np.max(
-            self._x_data[: self._data_count]
-        )
-        y_min, y_max = np.min(self._y_data[: self._data_count]), np.max(
-            self._y_data[: self._data_count]
-        )
-
-        # Add margin to the limits (5% on each side)
-        x_margin = np.float64(max(0.5, (x_max - x_min) * 0.05))
-        y_margin = np.float64(max(0.5, (y_max - y_min) * 0.05))
-
-        # Get current view limits
-        curr_x_min, curr_x_max = self.axes.get_xlim()
-        curr_y_min, curr_y_max = self.axes.get_ylim()
-
-        # Only adjust if data is outside current view or view is much larger than needed
-        need_x_update = (
-            x_min < curr_x_min + x_margin / 2
-            or x_max > curr_x_max - x_margin / 2
-            or curr_x_max - curr_x_min > (x_max - x_min + 2 * x_margin) * 1.5
-        )
-
-        need_y_update = (
-            y_min < curr_y_min + y_margin / 2
-            or y_max > curr_y_max - y_margin / 2
-            or curr_y_max - curr_y_min > (y_max - y_min + 2 * y_margin) * 1.5
-        )
-
-        if need_x_update:
-            self.axes.set_xlim(x_min - x_margin, x_max + x_margin)
-
-        if need_y_update:
-            self.axes.set_ylim(y_min - y_margin, y_max + y_margin)
-
-    def clear(self) -> None:
-        """
-        Clear all data points and reset the plot.
-        """
         self._data_count = 0
-        self.line.set_data([], [])
+        self._x_data[:] = 0
+        self._y_data[:] = 0
+        self.line.setData([], [])
+        super().clear()
 
-        # Reset to default limits
-        self.axes.set_xlim(0, 10)
-        self.axes.set_ylim(0, 10)
-
-        # Redraw the canvas
-        self.draw_idle()
-
+    # ------------------------------------------------------------------
     def set_title(self, title: str) -> None:
-        """
-        Set the title of the plot.
-
-        Args:
-            title (str): The new title
-        """
-        self.axes.set_title(title, fontsize=self.fontsize + 2)
+        self.setTitle(title)
         self._plot_config["title"] = title
-        self.draw_idle()
 
+    # ------------------------------------------------------------------
     def set_axis_labels(
         self, xlabel: Optional[str] = None, ylabel: Optional[str] = None
     ) -> None:
-        """
-        Set the labels for the x and y axes.
-
-        Args:
-            xlabel (str, optional): Label for the x-axis
-            ylabel (str, optional): Label for the y-axis
-        """
         if xlabel is not None:
-            self.axes.set_xlabel(xlabel, fontsize=self.fontsize)
+            self.setLabel("bottom", xlabel)
             self._plot_config["xlabel"] = xlabel
-
         if ylabel is not None:
-            self.axes.set_ylabel(ylabel, fontsize=self.fontsize)
+            self.setLabel("left", ylabel)
             self._plot_config["ylabel"] = ylabel
 
-        self.draw_idle()
-
+    # ------------------------------------------------------------------
     def set_max_points(self, max_points: int) -> None:
-        """
-        Change the maximum number of points to display.
-
-        Args:
-            max_points (int): New maximum number of points
-        """
         if max_points <= 0:
             return
 
+        new_x = np.zeros(max_points)
+        new_y = np.zeros(max_points)
+
+        copy_count = min(self._data_count, max_points)
+        if copy_count > 0:
+            start_idx = max(0, self._data_count - max_points)
+            new_x[:copy_count] = self._x_data[start_idx : start_idx + copy_count]
+            new_y[:copy_count] = self._y_data[start_idx : start_idx + copy_count]
+
+        self._x_data = new_x
+        self._y_data = new_y
+        self._data_count = copy_count
         self.max_plot_points = max_points
 
-        # Create new data arrays with the new size
-        new_x_data = np.zeros(max_points)
-        new_y_data = np.zeros(max_points)
-
-        # Copy existing data, truncating if needed
-        if self._data_count > 0:
-            copy_count = min(self._data_count, max_points)
-            start_idx = max(0, self._data_count - max_points)
-            new_x_data[:copy_count] = self._x_data[start_idx : start_idx + copy_count]
-            new_y_data[:copy_count] = self._y_data[start_idx : start_idx + copy_count]
-
-        # Update data arrays and count
-        self._x_data = new_x_data
-        self._y_data = new_y_data
-        self._data_count = min(self._data_count, max_points)
-
-        # Update the plot
-        self.line.set_data(
+        self.line.setData(
             self._x_data[: self._data_count], self._y_data[: self._data_count]
         )
-        self._adjust_limits()
-        self.draw_idle()
+        self.autoRange()
+
+
+class HistogramWidget(pg.PlotWidget):
+    """Widget for displaying histograms."""
+
+    def __init__(
+        self,
+        bins: int = 50,
+        fontsize: int = 10,
+        xlabel: str = "Value",
+        ylabel: str = "Count",
+        title: str = "Histogram",
+    ) -> None:
+        super().__init__()
+
+        self.setBackground(None)
+        self.showGrid(x=True, y=True, alpha=0.3)
+
+        self.bins = bins
+        self.fontsize = fontsize
+
+        self.setLabel("bottom", xlabel)
+        self.setLabel("left", ylabel)
+        self.setTitle(title)
+
+        self._hist_item: Optional[pg.BarGraphItem] = None
+
+    # ------------------------------------------------------------------
+    def update_histogram(self, values: Iterable[float]) -> None:
+        """Update histogram with new values."""
+
+        vals = list(values)
+        if not vals:
+            self.clear()
+            return
+
+        hist, edges = np.histogram(vals, bins=self.bins)
+        width = edges[1] - edges[0]
+        x = edges[:-1] + width / 2.0
+
+        self.clear()
+        self._hist_item = pg.BarGraphItem(x=x, height=hist, width=width, brush="w")
+        self.addItem(self._hist_item)
+        self.autoRange()
+
+    # ------------------------------------------------------------------
+    def set_bins(self, bins: int) -> None:
+        if bins > 0:
+            self.bins = bins

--- a/tests/data_controller_test.py
+++ b/tests/data_controller_test.py
@@ -65,6 +65,7 @@ class DataControllerTests(unittest.TestCase):
             plot_widget=self.plot,
             display_widget=self.lcd,
             history_widget=self.history,
+            table_widget=None,
             max_history=3,
         )
 
@@ -98,8 +99,9 @@ class DataControllerTests(unittest.TestCase):
     def test_get_csv_data(self):
         self.ctrl.add_data_point(1, 2)
         csv_data = self.ctrl.get_csv_data()
-        self.assertEqual(csv_data[0], ["Index", "Value (µs)"])
-        self.assertEqual(csv_data[1], ["1", "2.0"])
+        self.assertEqual(csv_data[0], ["Index", "Value (µs)", "Time"])
+        self.assertEqual(csv_data[1][0], "1")
+        self.assertEqual(csv_data[1][1], "2.0")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- use pyqtgraph instead of matplotlib for plotting
- add `HistogramWidget` for the histogram tab
- store timestamps of each measurement and show them in the table
- update tests and dependencies

## Testing
- `QT_QPA_PLATFORM=offscreen python tests/run_tests.py` *(fails: arduino_test and main window tests)*

------
https://chatgpt.com/codex/tasks/task_e_68765ed2a0c8832ea9e53721133b6750